### PR TITLE
Fix cancelling all animations

### DIFF
--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -134,7 +134,9 @@ function EmoteCancel()
         if LocalPlayer.state.ptfx then
             PtfxStop()
         end
-        ClearPedTasks(ply)
+        if IsEntityPlayingAnim(ply, ChosenDict, ChosenAnimation, 3) then
+            StopAnimTask(ply, ChosenDict, ChosenAnimation, 2.0)
+        end
         DetachEntity(ply, true, false)
         CancelSharedEmote(ply)
         DestroyAllProps()


### PR DESCRIPTION
This makes it so if the player is running 1 animation from dpemotes and 1 scenario from a 3rd script could be a sitting script it wont cancel the sitting but only the animation from dpemotes which is very helpful when trying to do stuff such as sitting and eating, sitting and people trynna glitch off the seat doing a mission or smt. 